### PR TITLE
handler.py: Added number of unfinished actions

### DIFF
--- a/device_cloud/_core/handler.py
+++ b/device_cloud/_core/handler.py
@@ -930,11 +930,19 @@ class Handler(object):
 
         return constants.STATUS_SUCCESS
 
+    def num_unfinished(self):
+        """
+        Get number of unfulfilled requests
+        """
+        return len(self.mqtt._out_messages)
+
     def on_connect(self, mqtt, userdata, flags, rc):
         """
         Callback when MQTT Client connects to Cloud
         """
-
+        unfinished = self.num_unfinished()
+        if (unfinished > 0):
+            self.logger.info("Unfinished actions while MQTT disconnected - Total = %s", unfinished)
         # Check connection result from MQTT
         self.logger.info("MQTT connected: %s", mqttlib.connack_string(rc))
         if rc == 0:


### PR DESCRIPTION
num_unfinished() will return the number of requests that were attempted to be sent while the client was disconnected from the cloud.

Signed-off-by: lcc755 <lcc755@mun.ca>