### PR TITLE
handler.py: Add quiet mode

### DIFF
--- a/device_cloud/_core/handler.py
+++ b/device_cloud/_core/handler.py
@@ -88,9 +88,12 @@ class Handler(object):
             self.logger = logging.getLogger("APP NAME HERE")
         log_formatter = logging.Formatter(constants.LOG_FORMAT,
                                           datefmt=constants.LOG_TIME_FORMAT)
-        log_handler = logging.StreamHandler()
-        log_handler.setFormatter(log_formatter)
-        self.logger.addHandler(log_handler)
+
+        if not self.config.quiet:
+            log_handler = logging.StreamHandler()
+            log_handler.setFormatter(log_formatter)
+            self.logger.addHandler(log_handler)
+
         if self.config.log_file:
             log_file_handler = logging.FileHandler(self.config.log_file)
             log_file_handler.setFormatter(log_formatter)


### PR DESCRIPTION
Create a quiet configuration option to disable the logger from
setting up the StreamHandler to output to stdout.

Normal logging to log_file is unaffected.

Signed-off-by: Rob Woolley <rob.woolley@windriver.com>