### PR TITLE
handler.py: Added number of unfinished actions

### DIFF
--- a/device_cloud/_core/handler.py
+++ b/device_cloud/_core/handler.py
@@ -930,10 +930,20 @@ class Handler(object):
 
         return constants.STATUS_SUCCESS
 
+    def num_unfinished(self):
+        """
+        Get number of unfulfilled requests
+        """
+        return len(self.mqtt._out_messages)
+
     def on_connect(self, mqtt, userdata, flags, rc):
         """
         Callback when MQTT Client connects to Cloud
         """
+
+        unfinished = self.num_unfinished()
+        if unfinished > 0:
+            self.logger.info("%s messages are pending..", unfinished)
 
         # Check connection result from MQTT
         self.logger.info("MQTT connected: %s", mqttlib.connack_string(rc))

--- a/device_cloud/test/test_helpers.py
+++ b/device_cloud/test/test_helpers.py
@@ -89,6 +89,7 @@ def init_mock_mqtt():
             sleep(0.25)
         return 0
 
+    mock_mqtt._out_messages = []
     mock_mqtt.tls_set.return_value = 0
     mock_mqtt.connect.side_effect = mqtt_connect
     mock_mqtt.disconnect.side_effect = mqtt_disconnect


### PR DESCRIPTION
num_unfinished() will return the number of requests that were attempted to be sent while the client was disconnected from the cloud.

Signed-off-by: lcc755 <lcc755@mun.ca>