### PR TITLE
requirements.txt: remove unneed module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ queues==0.6.3
 requests==2.9.1
 requests-toolbelt==0.8.0
 simplejson==3.8.1
-urlgrabber==3.9.1
 urllib3==1.13.1
 websocket==0.2.1
 websocket-client==0.44.0


### PR DESCRIPTION
Remove urlgrabber, it is not required.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>