### PR TITLE
service: add WorkingDirectory to the service file.

### DIFF
--- a/share/device-manager.service
+++ b/share/device-manager.service
@@ -22,6 +22,8 @@ Restart=always
 StandardOutput=journal
 StandardError=journal
 KillMode=process
+# deployment scripts should substitute this with the correct value.
+#WorkingDirectory=WORKING_DIRECTORY
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On an installed and deployed system like IDP, the device_id is written
to the CWD, e.g. systemd working directory, which defaults to "/".
Change the working directory to /var/lib/python-device-manager, or
whatever the systems directory name is.  This commit leaves the
WorkingDirectory setting commented out.  So, deployment scripts will
need to substitute and uncomment, if required.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>