### PR TITLE
Add quiet mode and user timestamp support

### DIFF
--- a/device_cloud/_core/client.py
+++ b/device_cloud/_core/client.py
@@ -507,7 +507,7 @@ class Client(object):
                                         accuracy=accuracy, fix_type=fix_type)
         return self.handler.queue_publish(location)
 
-    def telemetry_publish(self, telemetry_name, value):
+    def telemetry_publish(self, telemetry_name, value, timestamp=None):
         """
         Publish telemetry to the Cloud
 
@@ -519,6 +519,6 @@ class Client(object):
           STATUS_SUCCESS               Telemetry has been queued for publishing
         """
 
-        telem = defs.PublishTelemetry(telemetry_name, value)
+        telem = defs.PublishTelemetry(telemetry_name, value, timestamp)
         return self.handler.queue_publish(telem)
 

--- a/device_cloud/_core/defs.py
+++ b/device_cloud/_core/defs.py
@@ -396,8 +396,10 @@ class PublishTelemetry(Publish):
     Holds information about telemetry that is to be published
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name, value, timestamp=None):
         super(PublishTelemetry, self).__init__()
+        if type(timestamp) is datetime:
+            self.timestamp = timestamp.strftime(constants.TIME_FORMAT)
         self.name = name
         self.value = value
 

--- a/device_cloud/_core/handler.py
+++ b/device_cloud/_core/handler.py
@@ -88,9 +88,12 @@ class Handler(object):
             self.logger = logging.getLogger("APP NAME HERE")
         log_formatter = logging.Formatter(constants.LOG_FORMAT,
                                           datefmt=constants.LOG_TIME_FORMAT)
-        log_handler = logging.StreamHandler()
-        log_handler.setFormatter(log_formatter)
-        self.logger.addHandler(log_handler)
+
+        if not self.config.quiet:
+            log_handler = logging.StreamHandler()
+            log_handler.setFormatter(log_formatter)
+            self.logger.addHandler(log_handler)
+
         if self.config.log_file:
             log_file_handler = logging.FileHandler(self.config.log_file)
             log_file_handler.setFormatter(log_formatter)


### PR DESCRIPTION
Create a quiet configuration option to disable the logger from setting up the StreamHandler to output to stdout. Normal logging to a log_file is unaffected.

Allow the user to submit a custom timestamp when publishing properties.

Signed-off-by: Rob Woolley <rob.woolley@windriver.com>