### PR TITLE
Cloud_response: Wait for response from cloud

### DIFF
--- a/demo/iot-simple-telemetry.py
+++ b/demo/iot-simple-telemetry.py
@@ -33,6 +33,10 @@ import device_cloud as iot
 running = True
 sending_telemetry = False
 
+# Return status once the cloud responds
+# Default is false
+cloud_response = False
+
 # Second intervals between telemetry
 TELEMINTERVAL = 4
 
@@ -133,7 +137,14 @@ if __name__ == "__main__":
                 for p in properties:
                     value = round(random.random()*1000, 2)
                     client.info("Publishing %s to %s", value, p)
-                    client.telemetry_publish(p, value)
+                    status = client.telemetry_publish(p, value, cloud_response)
+                    # Log response from cloud
+                    if cloud_response:
+                        if status == iot.STATUS_SUCCESS:
+                            client.log(iot.LOGINFO, "Telemetry Publish - SUCCESS")
+                        else:
+                            client.log(iot.LOGERROR, "Telemetry Publish - FAIL")
+
                 for a in attributes:
                     value = "".join(random.choice("abcdefghijklmnopqrstuvwxyz")
                                     for x in range(20))

--- a/device_cloud/_core/client.py
+++ b/device_cloud/_core/client.py
@@ -450,6 +450,7 @@ class Client(object):
             if not result:
                 return STATUS_NOT_FOUND
             return max(result)
+
         return self.handler.request_upload(file_path, upload_name, blocking,
                                            callback, timeout, file_global)
 
@@ -498,18 +499,21 @@ class Client(object):
                                         accuracy=accuracy, fix_type=fix_type)
         return self.handler.queue_publish(location)
 
-    def telemetry_publish(self, telemetry_name, value, timestamp=None):
+    def telemetry_publish(self, telemetry_name, value, cloud_response=False, timestamp=None):
         """
         Publish telemetry to the Cloud
 
         Parameters:
           telemetry_name      (string) Key of property to publish
           value               (number) Value to publish
-
+          cloud_response      (bool) Wait for response from cloud
+                                     If true, the return status indicates if
+                                     it was sent to the cloud. Otherwise,
+                                     the return status is if it was queued.
         Returns:
-          STATUS_SUCCESS               Telemetry has been queued for publishing
+          STATUS_SUCCESS             Telemetry has been queued for publishing
         """
 
         telem = defs.PublishTelemetry(telemetry_name, value, timestamp)
-        return self.handler.queue_publish(telem)
+        return self.handler.request_publish(telem, cloud_response)
 

--- a/device_cloud/_core/client.py
+++ b/device_cloud/_core/client.py
@@ -450,7 +450,6 @@ class Client(object):
             if not result:
                 return STATUS_NOT_FOUND
             return max(result)
-
         return self.handler.request_upload(file_path, upload_name, blocking,
                                            callback, timeout, file_global)
 

--- a/device_cloud/_core/handler.py
+++ b/device_cloud/_core/handler.py
@@ -1198,7 +1198,6 @@ class Handler(object):
                 self.topic_counter += 1
                 if topic_num not in self.reply_tracker:
                     break
-
             self.pub_topic = topic_num
             # Send payload over MQTT
             result, mid = self.mqtt.publish("api/{}".format(topic_num),


### PR DESCRIPTION
Resolves #141

Added option to wait for actual response from cloud while publishing telemetry.
If false, operates as before.

Signed-off-by: lcc755 <lcc755@mun.ca>