### PR TITLE
Some small fixes

### DIFF
--- a/share/admin-tools/app_defs/hdc_device_manager_app.cfg
+++ b/share/admin-tools/app_defs/hdc_device_manager_app.cfg
@@ -3,7 +3,7 @@
     "app_definitions":[
     {
         "name":"hdc_device_manager_app",
-        "desc":"hdc_device_manager_app",
+        "desc":"Device Manager App",
         "token":"",
         "autoRegThingDefId":"hdc_device_manager_def",
         "autoRegTags":["", ""],

--- a/share/admin-tools/thing_defs/demo_defs.cfg
+++ b/share/admin-tools/thing_defs/demo_defs.cfg
@@ -40,15 +40,28 @@
                 }
             },
             "alarms": {
-                "alarm_1": {
-                    "name": "Alarm 1",
+                "telemetry_alarm": {
+                    "name": "Telemetry Alarm",
                     "states": [
                         {
-                            "name": "Good",
+                            "name": "ON",
                             "color": "#00F020"
                         },
                         {
-                            "name": "Bad",
+                            "name": "OFF",
+                            "color": "#ED0707"
+                        }
+                    ]
+                },
+               "trigger_alarm": {
+                    "name": "Trigger Alarm",
+                    "states": [
+                        {
+                            "name": "ON",
+                            "color": "#00F020"
+                        },
+                        {
+                            "name": "OFF",
                             "color": "#ED0707"
                         }
                     ]

--- a/share/admin-tools/thing_defs/hdc_device_manager_def.cfg
+++ b/share/admin-tools/thing_defs/hdc_device_manager_def.cfg
@@ -2,16 +2,10 @@
     "thing_definitions":[
     {
         "key": "hdc_device_manager_def",
-        "name": "hdc_device_manager_def",
+        "name": "Device Manager",
         "version": 20,
         "autoDefProps": false,
         "autoDefAttrs": false,
-        "properties": {
-        "py_property_publish_int": {
-            "name": "py_property_publish_int",
-            "calcAggregates": false
-        }
-        },
         "attributes": {
         "architecture": {
             "name": "System Architecture",
@@ -88,17 +82,17 @@
             "description": "If file_path is relative, send file to the runtime download directory",
             "notificationVariables": {
             "file_name": {
-                "name": "file_name (for file in cloud)",
+                "name": "File Name (for file in cloud)",
                 "type": "string",
                 "uiType": "text"
             },
             "file_path": {
-                "name": "file_path (including file name)",
+                "name": "File Path (including file name)",
                 "type": "string",
                 "uiType": "text"
             },
             "use_global_store": {
-                "name": "use_global_store",
+                "name": "Use Global Store",
                 "type": "bool",
                 "uiType": "checkbox"
             }
@@ -109,17 +103,17 @@
             "description": "If file_path is relative, look for file in the runtime upload directory",
             "notificationVariables": {
             "file_name": {
-                "name": "file_name (for file in cloud)",
+                "name": "File Name (for file in cloud)",
                 "type": "string",
                 "uiType": "text"
             },
             "file_path": {
-                "name": "file_path (including file name)",
+                "name": "File Path (including file name)",
                 "type": "string",
                 "uiType": "text"
             },
             "use_global_store": {
-                "name": "use_global_store",
+                "name": "Use Global Store",
                 "type": "bool",
                 "uiType": "checkbox"
             }


### PR DESCRIPTION
    Add a few small fixes:
      * change the alarm name to telemetry_alarm
      * change the return of a string to an out parameter.  This way, the
      result is not an error when using triggers
      * use UTC time for the example of telemetry with a timestamp.  This
      way the cloud can overlay telemetry and alarms with the same
      timezone.
    
    Update the thing def templates.  This commit harmonizes the device
    manager thing def for the Clib and python.
