### PR TITLE
device_manager.py: add simple ping device callback

### DIFF
--- a/device_manager.py
+++ b/device_manager.py
@@ -33,6 +33,7 @@ import uuid
 import argparse
 import tarfile
 import socket
+from datetime import datetime
 
 from device_cloud import osal
 from device_cloud import ota_handler
@@ -462,6 +463,18 @@ def remote_access(client, params):
         client.error(str(error))
         return (iot.STATUS_FAILURE, str(error))
 
+def sign_of_life(client, params):
+    """
+    Callback to respond to the cloud.  Used for a simple sign of life.
+    This callback takes no inbound parameters, and uses an out
+    paramter.
+    """
+    p = {}
+    p['response'] = "acknowledged"
+    ts = datetime.utcnow()
+    p['time_stamp'] =  ts.strftime("%Y-%m-%d %H:%M:%S")
+    return (iot.STATUS_SUCCESS, "", p)
+
 if __name__ == "__main__":
     signal.signal(signal.SIGINT, sighandler)
     if osal.POSIX:
@@ -554,6 +567,9 @@ if __name__ == "__main__":
                                 (runtime_dir, ota, [app_id, default_cfg_dir, config_file]))
 
     action_register_conditional(client, "quit", quit_me, \
+                                config.actions_enabled.reset_agent)
+
+    action_register_conditional(client, "ping", sign_of_life, \
                                 config.actions_enabled.reset_agent)
 
     # Connect to Cloud

--- a/share/admin-tools/thing_defs/hdc_device_manager_def.cfg
+++ b/share/admin-tools/thing_defs/hdc_device_manager_def.cfg
@@ -119,6 +119,10 @@
             }
             }
         },
+        "ping": {
+            "name": "Ping Device",
+            "description": "Ping Device"
+        },
         "quit": {
             "name": "Quit App",
             "description": "Stops the Device Manager"


### PR DESCRIPTION
Add an action designed to quickly test connectivity from cloud to
device.  The callback will return two out parameters:
  * status
  * time_stamp
The method in the cloud will be called "Ping Device".  The response
will be e.g.:
	{
	    "response": "acknowledged",
	    "time_stamp": "2018-02-06 21:44:07"
	}
Signed-off-by: Paul Barrette <paulbarrette@gmail.com>