### PR TITLE
handler.py: support extra on-prem connection options

### DIFF
--- a/device_cloud/_core/handler.py
+++ b/device_cloud/_core/handler.py
@@ -652,7 +652,17 @@ class Handler(object):
         status = constants.STATUS_SUCCESS
         self.logger.info("Downloading \"%s\"", file_xfer_obj.file_name)
         self.logger.info("File size \"%d\"", file_xfer_obj.file_size)
-        url = "https://{}/file/{}".format(self.config.cloud.host, file_xfer_obj.file_id)
+
+        # on prem solutions might not have port 443 for file xfer, so
+        # support a config option in iot-connect.cfg for xfer host and
+        # port.
+        host = self.config.cloud.host
+        if self.config.cloud.file_xfer_host:
+            host = self.config.cloud.file_xfer_host
+        if self.config.cloud.file_xfer_port:
+            host += ":" + str(self.config.cloud.file_xfer_port)
+
+        url = "https://{}/file/{}".format(host, file_xfer_obj.file_id)
         download_dir = os.path.dirname(file_xfer_obj.file_path)
         temp_file_name = "".join([random.choice("0123456789") for _ in range(10)])
         temp_file_name += ".part"

--- a/generate_config.py
+++ b/generate_config.py
@@ -32,6 +32,9 @@ proxy_host_desc = "\nProxy host address"
 proxy_port_desc = "\nProxy port"
 proxy_username_desc = "\nProxy username (Optional)"
 proxy_password_desc = "\nProxy password (Optional)"
+onprem_desc = "\nSet on-prem special conifguration? (default false) (Optional)"
+onprem_file_xfer_host_desc = "\nOn-prem set a different host for file transfer? (Optional)"
+onprem_file_xfer_port_desc = "\nOn-prem set a different port for file transfer (Optional)"
 
 negatives = ["false", "f", "no", "n"]
 positives = ["true", "t", "yes", "y"]
@@ -47,6 +50,8 @@ def generate():
     parser.add_argument("--proxy-port", type=int, help=proxy_port_desc)
     parser.add_argument("--proxy-username", help=proxy_username_desc)
     parser.add_argument("--proxy-password", help=proxy_password_desc)
+    parser.add_argument("--onprem-file-xfer-host", help=onprem_file_xfer_host_desc)
+    parser.add_argument("--onprem-file-xfer-port", help=onprem_file_xfer_port_desc)
 
     args = parser.parse_args(sys.argv[1:])
     file_name = ""
@@ -91,6 +96,12 @@ def generate():
                 config["proxy"]["username"] = args.proxy_username
             if args.proxy_password:
                 config["proxy"]["password"] = args.proxy_password
+
+        # On Prem config options
+        if (args.onprem_file_xfer_host):
+            config["cloud"]["file_xfer_host"] = args.onprem_file_xfer_host
+        if (args.onprem_file_xfer_port):
+            config["cloud"]["file_xfer_port"] = args.onprem_file_xfer_port
 
         if missing:
             print("Missing {}. Try again.".format(", ".join(missing)))
@@ -181,6 +192,19 @@ def generate():
             temp = input("# ").strip()
             if temp:
                 config["proxy"]["password"] = temp
+
+        print(onprem_desc)
+        temp = input("# ").strip()
+        if temp:
+            print(onprem_file_xfer_host_desc)
+            temp = input("# ").strip()
+            if temp:
+                config["cloud"]["file_xfer_host"] = temp
+
+            print(onprem_file_xfer_port_desc)
+            temp = input("# ").strip()
+            if temp:
+                config["cloud"]["file_xfer_port"] = temp
 
     if not os.path.splitext(file_name)[1]:
         file_name += ".cfg"


### PR DESCRIPTION
Resolves #262
Some on-prem deployments may use a different host/port for file
transfer.  Update the generate_config.py to prompt for additional
on-prem configuration.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>